### PR TITLE
POD and perl critic tweaks

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -19,6 +19,7 @@ repository.type   = git
 [ExecDir]
 [ExtraTests]
 [Test::Perl::Critic]
+[PodSyntaxTests]
 [GatherDir]
 [License]
 [MakeMaker]

--- a/dist.ini
+++ b/dist.ini
@@ -18,6 +18,7 @@ repository.type   = git
 ; Build
 [ExecDir]
 [ExtraTests]
+[Test::Perl::Critic]
 [GatherDir]
 [License]
 [MakeMaker]
@@ -25,7 +26,7 @@ repository.type   = git
 [Manifest]
 [MetaJSON]
 [MetaYAML]
-[PkgVersion]
+[OurPkgVersion]
 [PodWeaverIfPod]
 [PruneCruft]
 

--- a/dist.ini
+++ b/dist.ini
@@ -29,6 +29,7 @@ repository.type   = git
 [OurPkgVersion]
 [PodWeaverIfPod]
 [PruneCruft]
+[MinimumPerl]
 
 [Prereqs / RuntimeRequires]
 File::Find::Wanted = 0

--- a/lib/Any/Template/ProcessDir.pm
+++ b/lib/Any/Template/ProcessDir.pm
@@ -213,7 +213,7 @@ templates, specify I<source_dir> and I<dest_dir>.
 
     my $pd = Any::Template::ProcessDir->new(
         source_dir => '/path/to/source/dir',
-        source_dir => '/path/to/dest/dir',
+        dest_dir => '/path/to/dest/dir',
         ...
     );
 

--- a/lib/Any/Template/ProcessDir.pm
+++ b/lib/Any/Template/ProcessDir.pm
@@ -10,6 +10,7 @@ use Moose::Util::TypeConstraints;
 use Try::Tiny;
 use strict;
 use warnings;
+#VERSION
 
 has 'dest_dir'             => ( is => 'ro' );
 has 'dir'                  => ( is => 'ro' );


### PR DESCRIPTION
Edited the dist.ini so that the POD is verified before release.
Edited the dist.ini so that it runs perlcritic before release.
Edited the dist.ini so that it properly identifies the minimum perl version required.

Fixed a minor typo in the POD
Changed to OurPkgVersion to fix a perlcritic warning caused by PkgVersion
